### PR TITLE
Remove CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-anniechen.me


### PR DESCRIPTION
Hello! I have already purchased the domain name anniechen.me. However, because you created the CNAME file before me, it will not allow me to use the domain as my URL appropriately. To prove that I have indeed bought the domain, feel free to type anniechen.me into your browser. You will see that I have already put a hard redirect to my site. I would greatly appreciate if you could remove this domain from your CNAME file. Thank you for your consideration!